### PR TITLE
dependencyLookup: Looks up the real paths of aliased dependency names

### DIFF
--- a/bin/dependencyLookup.js
+++ b/bin/dependencyLookup.js
@@ -1,0 +1,10 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var lookup = require('../lib/lookup');
+
+var config = process.argv[2];
+var path = process.argv[3];
+
+console.log(lookup(config, path));

--- a/lib/lookup.js
+++ b/lib/lookup.js
@@ -1,0 +1,31 @@
+var ConfigFile = require('requirejs-config-file').ConfigFile;
+
+/**
+ * Determines the real path of a potentially aliased dependency path
+ * via the paths section of a require config
+ *
+ * @param  {String|Object} config - Pass a loaded config object if you'd like to avoid rereading the config
+ * @param  {String} depPath
+ * @return {String}
+ */
+module.exports = function(config, depPath) {
+  if (typeof config === 'string') {
+    config = new ConfigFile(config).read();
+  }
+
+  var pathTokens = depPath.split('/');
+
+  // Check if the top-most dir of path is an alias
+  var alias = config.paths[pathTokens[0]];
+
+  if (alias) {
+    alias = alias[alias.length - 1] === '/' ? alias : alias + '/';
+
+    // @todo: handle alias values that are relative paths
+    // use the absolute path of the config for resolution
+
+    depPath = alias + pathTokens.slice(1).join('/');
+  }
+
+  return depPath;
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Get the modules that depend on a given module",
   "main": "index.js",
   "bin": {
-    "dependents": "bin/dependents.js"
+    "dependents": "bin/dependents.js",
+    "dependency-lookup": "bin/dependencyLookup.js"
   },
   "scripts": {
     "test": "node test/test.js"
@@ -28,6 +29,7 @@
     "node-dir": "~0.1.5",
     "node-source-walk": "~1.1.1",
     "q": "~1.0.1",
+    "requirejs-config-file": "~2.0.0",
     "shims": "~1.0.0"
   }
 }


### PR DESCRIPTION
Fixes #6 

Complements: https://github.com/mrjoelkemp/sublime-dependents/pull/27
