### PR TITLE
Resolve underscored sass partials from non-underscored import path

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,11 @@ module.exports = function dependents(options) {
   processFiles(options);
 };
 
+/**
+ * @private
+ * @param  {String} configPath
+ * @return {Object}
+ */
 module.exports._readConfig = function(configPath) {
   return new ConfigFile(configPath).read();
 };
@@ -69,7 +74,7 @@ function processFiles(options) {
       dependents: options.dependents,
       config: options.config
     });
-  }
+  };
 
   var _excludes = util.DEFAULT_EXCLUDE_DIR.concat(options.exclusions);
   var exclusions = util.processExcludes(_excludes, directory);

--- a/test/example/sass/stylesUnderscore.scss
+++ b/test/example/sass/stylesUnderscore.scss
@@ -1,0 +1,1 @@
+@import "foo";

--- a/test/test.js
+++ b/test/test.js
@@ -176,7 +176,20 @@ describe('dependents', function() {
         filename: __dirname + '/example/sass/_foo.scss',
         directory: __dirname + '/example/sass',
         success: function(err, dependents) {
-          assert(dependents.length === 2);
+          assert(dependents.length === 3);
+          done();
+        }
+      });
+    });
+
+    it('handles sass partials with underscored files', function(done) {
+      dependents({
+        filename: __dirname + '/example/sass/_foo.scss',
+        directory: __dirname + '/example/sass',
+        success: function(err, dependents) {
+          assert(dependents.some(function(dep) {
+            return dep.indexOf('stylesUnderscore.scss') !== -1;
+          }));
           done();
         }
       });


### PR DESCRIPTION
Related to https://github.com/mrjoelkemp/sublime-dependents/issues/101